### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,8 @@ This documentation serves as context when developing features and can be used wi
 ## ⚙️ Environment Variables
 
 No environment variables are required as the server automatically locates the iMessage database in the default macOS location.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hannesrudolph-imessage-query-fastmcp-mcp-server).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hannesrudolph-imessage-query-fastmcp-mcp-server).